### PR TITLE
Add a method in store to reset configuration (#fix 50)

### DIFF
--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -3,6 +3,37 @@ const app = {
   getAppMode () {
     return store.state.appMode
   },
+  resetConfig () {
+    store.state.appMode = 'full'
+    store.state.navigationMode = 'forward'
+    store.state.isRouterEnabled = false
+    store.state.router = {}
+    store.state.history = []
+    store.state.backwardNavigation = false
+    store.state.componentList = {}
+    store.state.goBackView = ''
+    store.state.lastView = ''
+    store.state.diameters = {}
+    store.state.sizes = {
+      xxl: 55,
+      xl: 32,
+      l: 20,
+      m: 12,
+      s: 8,
+      xs: 5,
+      xxs: 2
+    }
+    store.state.appStyle = {
+      theme: 'theme-black',
+      mode: 'mode-dark',
+      shape: 'circle'
+    }
+    store.state.currentPage = 0
+    store.state.items = []
+    store.state.pages = []
+    store.state.params = {}
+    store.state.debug = false
+  },
   config (config) {
     if (config.debug === true || config.debug === false) store.state.debug = config.debug
     if (store.state.debug === true) {


### PR DESCRIPTION
This PR aims to add a method to reset zircle configuration.
It's needed to fix #50: after going to another page, reset the configuration allow to see zircle correctly

There are several things I don't like:
1. All configuration values are used twice in the project (in `store/state.js` and now in `store/modules/app.js`). I think it's possible to use a single object in both cases.
2. It is not automatic: I have to execute the resetConfig method when the user comes from another page to solve the problem. The real problem is not solved, I don't know what parameters cause this issue(described in #50)
