### PR TITLE
Use unique key on transition-group children in z-view-manager

### DIFF
--- a/src/components/child-components/z-view-manager.vue
+++ b/src/components/child-components/z-view-manager.vue
@@ -1,19 +1,18 @@
 <template>
   <transition-group :name="$zircle.getNavigationMode() === 'forward' ? 'z-next' : 'z-prev'" tag="section">
     <component
-      v-for="(view, i) in views"
+      v-for="view in views"
       :is="view.component"
       :class="{
         'is-current-view': $zircle.getCurrentViewName() === view.name,
         'is-previous-view': $zircle.getPreviousViewName() === view.name,
         'is-past-view': $zircle.getPastViewName() === view.name
       }"
-      :key="i">
+      :key="view.uniqueKey">
     </component>
   </transition-group>
 </template>
 <script>
-/* eslint-disable */
 export default {
   name: 'z-view-manager',
   computed: {

--- a/src/store/modules/navigation.js
+++ b/src/store/modules/navigation.js
@@ -1,5 +1,6 @@
 import store from '../store'
 import Vue from 'vue'
+import { createUniqueKey } from '../utils'
 
 function retrieveViewName (pos) {
   let viewName = ''
@@ -51,6 +52,7 @@ function parseView (data) {
 const navigation = {
   addToHistory (view, position, params) {
     return store.state.history.push({
+      uniqueKey: createUniqueKey(),
       name: view.name,
       position,
       params,

--- a/src/store/modules/router.js
+++ b/src/store/modules/router.js
@@ -1,11 +1,19 @@
 import store from '../store'
+import { createUniqueKey } from '../utils'
+
 const router = {
   evaluateRoute (view, position) {
     const match = store.state.router.resolve(view.path).route.matched[0]
     const component = match.components.default
     const name = match.name
     store.actions.setComponentList({ [name]: component })
-    store.state.history.push({ name, position, params: view.route.params, component })
+    store.state.history.push({
+      uniqueKey: createUniqueKey(),
+      name,
+      position,
+      params: view.route.params,
+      component
+    })
     store.actions.setNavigationMode('forward')
     if (view.name !== name) {
       return store.state.router.push({ name, params: view.route.params })
@@ -19,7 +27,13 @@ const router = {
     store.state.params = ''
     store.state.history = []
     store.actions.setComponentList({ [view.name]: component })
-    store.state.history.push({ name: view.name, position: { X: 0, Y: 0, scale: 1, Xi: 0, Yi: 0, scalei: 1 }, params: view.params, component })
+    store.state.history.push({
+      uniqueKey: createUniqueKey(),
+      name: view.name,
+      position: { X: 0, Y: 0, scale: 1, Xi: 0, Yi: 0, scalei: 1 },
+      params: view.params,
+      component
+    })
     store.actions.setNavigationMode('forward')
     store.state.router.replace(view)
     store.actions.setLog('replace() => ' + store.state.history[store.state.history.length - 1].name)

--- a/src/store/utils.js
+++ b/src/store/utils.js
@@ -1,0 +1,1 @@
+export const createUniqueKey = () => Date.now().toString(36) + Math.random().toString(36).substring(2)


### PR DESCRIPTION
I changed the :key in z-view-manager because of a warning message : 
> "Do not use v-for index as key on <transition-group> children, this is the same as not using keys."

After reading this: https://stackoverflow.com/a/64218312/5572544
I think that an unique key on views pushed in history is the best solution.
