### PR TITLE
Minor global refactoring

### DIFF
--- a/src/components/child-components/z-view-manager.vue
+++ b/src/components/child-components/z-view-manager.vue
@@ -1,19 +1,18 @@
 <template>
   <transition-group :name="$zircle.getNavigationMode() === 'forward' ? 'z-next' : 'z-prev'" tag="section">
     <component
-      v-for="(view, i) in views"
+      v-for="view in views"
       :is="view.component"
       :class="{
         'is-current-view': $zircle.getCurrentViewName() === view.name,
         'is-previous-view': $zircle.getPreviousViewName() === view.name,
         'is-past-view': $zircle.getPastViewName() === view.name
       }"
-      :key="`${view.name}_${i}}`">
+      :key="view.uniqueKey">
     </component>
   </transition-group>
 </template>
 <script>
-/* eslint-disable */
 export default {
   name: 'z-view-manager',
   computed: {

--- a/src/components/z-dialog.vue
+++ b/src/components/z-dialog.vue
@@ -59,8 +59,7 @@ export default {
       componentType: this.$options.name,
       progress: 0,
       scrollVal: -45,
-      isMounted: false,
-      ffox: false
+      isMounted: false
     }
   },
   computed: {

--- a/src/components/z-dialog.vue
+++ b/src/components/z-dialog.vue
@@ -89,13 +89,10 @@ export default {
       )
     },
     shape () {
-      if (this.circle) {
-        return 'is-circle'
-      } else if (this.square) {
+      if (this.square) {
         return 'is-square'
-      } else {
-        return 'is-circle'
       }
+      return 'is-circle'
     },
     styles () {
       const zwidth = this.$zircle.getComponentWidth(this.size)

--- a/src/components/z-spot.vue
+++ b/src/components/z-spot.vue
@@ -9,27 +9,33 @@
     @mousedown="pulse"
     @touchstart="pulse"
     @mouseup="move"
-    @click="$emit('click', $event)">
-      <div v-if="!button" ref="spot" class="z-outer-spot" :class="[shape]" :style="styles.plate"></div>
-      <div class="z-pulse" :class="[shape]" ref="pulse"></div>
-      <z-knob v-if="knobEnabled" :qty="computedQty" :unit="unit" :min="min" :max="max" />
-      <z-slider v-if="sliderEnabled" :progress='progress' />
-      <div class="z-label" :class="[shape,labelPos]" :style="$zircle.getThemeMode() === 'mode-light-filled' ? 'color: var(--accent-text-and-border-color);' : ''" v-if="label">
-        <div class="inside">
-        {{label}} <span v-if="pos === 'outside'"> {{progressLabel}}</span>
-        </div>
+    @click="$emit('click', $event)"
+  >
+    <div v-if="!button" ref="spot" class="z-outer-spot" :class="[shape]" :style="styles.plate"></div>
+    <div class="z-pulse" :class="[shape]" ref="pulse"></div>
+    <z-knob v-if="knobEnabled" :qty="computedQty" :unit="unit" :min="min" :max="max"/>
+    <z-slider v-if="sliderEnabled" :progress='progress'/>
+    <div
+      class="z-label"
+      :class="[shape,labelPos]"
+      :style="$zircle.getThemeMode() === 'mode-light-filled' ? 'color: var(--accent-text-and-border-color);' : ''"
+      v-if="label"
+    >
+      <div class="inside">
+        {{ label }} <span v-if="pos === 'outside'"> {{ progressLabel }}</span>
       </div>
-      <div class="z-content" :class="[shape]" >
-        <img v-if="imagePath" :src="imagePath" width="100%" height="100%" alt="content custom image"/>
-        <slot v-if="!imagePath" name="image"></slot>
-      </div>
-      <div class="z-content" :class="[shape]"  style="z-index: 10">
-        <span class="overflow">
-          <span v-if="pos === 'inside' || pos === undefined ">{{progressLabel}}</span>
-          <slot></slot>
-        </span>
-      </div>
-      <slot name="extension"></slot>
+    </div>
+    <div class="z-content" :class="[shape]">
+      <img v-if="imagePath" :src="imagePath" width="100%" height="100%" alt="content custom image"/>
+      <slot v-if="!imagePath" name="image"></slot>
+    </div>
+    <div class="z-content" :class="[shape]" style="z-index: 10">
+      <span class="overflow">
+        <span v-if="pos === 'inside' || pos === undefined ">{{ progressLabel }}</span>
+        <slot></slot>
+      </span>
+    </div>
+    <slot name="extension"></slot>
   </div>
 </template>
 
@@ -148,13 +154,7 @@ export default {
       return this.$zircle.getNumberOfItemsInCurrentPage() === 1 ? 0 : this.distance
     },
     responsive () {
-      if (this.view === this.$zircle.getCurrentViewName()) {
-        // eslint-disable-next-line
-        this.zpos = this.styles
-        return true
-      } else {
-        return false
-      }
+      return this.view === this.$zircle.getCurrentViewName()
     },
     shape () {
       if (this.square) {

--- a/src/components/z-spot.vue
+++ b/src/components/z-spot.vue
@@ -152,13 +152,10 @@ export default {
       }
     },
     shape () {
-      if (this.circle) {
-        return 'is-circle'
-      } else if (this.square) {
+      if (this.square) {
         return 'is-square'
-      } else {
-        return 'is-circle'
       }
+      return 'is-circle'
     },
     sliderEnabled () {
       return this.slider === true && this.shape === 'is-circle'

--- a/src/components/z-spot.vue
+++ b/src/components/z-spot.vue
@@ -124,6 +124,11 @@ export default {
       val: 0
     }
   },
+  watch: {
+    responsive () {
+      this.zpos = this.styles
+    }
+  },
   computed: {
     position () {
       const component = {

--- a/src/components/z-view.vue
+++ b/src/components/z-view.vue
@@ -99,13 +99,10 @@ export default {
   },
   computed: {
     shape () {
-      if (this.circle) {
-        return 'is-circle'
-      } else if (this.square) {
+      if (this.square) {
         return 'is-square'
-      } else {
-        return 'is-circle'
       }
+      return 'is-circle'
     },
     sliderEnabled () {
       return this.slider === true && this.shape === 'is-circle'

--- a/src/components/z-view.vue
+++ b/src/components/z-view.vue
@@ -88,7 +88,6 @@ export default {
       scrollVal: -45,
       zpos: {},
       isMounted: false,
-      ffox: false,
       fullView: this.$zircle.getNavigationMode() === 'forward' ? this.$zircle.getCurrentViewName() : this.$zircle.getPastViewName()
     }
   },

--- a/src/store/modules/navigation.js
+++ b/src/store/modules/navigation.js
@@ -1,5 +1,6 @@
 import store from '../store'
 import Vue from 'vue'
+import { createUniqueKey } from '../utils'
 
 function retrieveViewName (pos) {
   let viewName = ''
@@ -51,6 +52,7 @@ function parseView (data) {
 const navigation = {
   addToHistory (view, position, params) {
     return store.state.history.push({
+      uniqueKey: createUniqueKey(),
       name: view.name,
       position,
       params,

--- a/src/store/modules/navigation.js
+++ b/src/store/modules/navigation.js
@@ -65,22 +65,37 @@ const navigation = {
   toView (options) {
     if (typeof options === 'string') {
       store.actions.setView(options)
-    } else {
-      if (!options.to) store.actions.setLog('Programmatic navigation: "to" is required ', 'error')
-      if (!options.fromSpot) store.actions.setLog('Programmatic navigation: "fromSpot" is required ', 'error')
-      if (options.fromSpot && typeof options.fromSpot !== 'object') store.actions.setLog('Programmatic navigation: "fromSpot" should be an object ', 'error')
-      if (options.params && typeof options.params !== 'object') store.actions.setLog('Programmatic navigation: "params" should be an object ', 'error')
-      if (options.to && options.fromSpot) {
-        if (!options.params) options.params = {}
-        const positionParams = options.fromSpot.position ? { position: { X: options.fromSpot.position.Xabs, Y: options.fromSpot.position.Yabs, scale: options.fromSpot.position.scale, Xi: options.fromSpot.position.Xi, Yi: options.fromSpot.position.Yi, scalei: options.fromSpot.position.scalei } } : {}
-        store.actions.setView(
-          {
-            name: options.to,
-            params: options.params
-          },
-          positionParams
-        )
+      return
+    }
+    if (!options.to) store.actions.setLog('Programmatic navigation: "to" is required ', 'error')
+    if (!options.fromSpot) store.actions.setLog('Programmatic navigation: "fromSpot" is required ', 'error')
+    if (options.fromSpot && typeof options.fromSpot !== 'object') store.actions.setLog('Programmatic navigation: "fromSpot" should be an object ', 'error')
+    if (options.params && typeof options.params !== 'object') store.actions.setLog('Programmatic navigation: "params" should be an object ', 'error')
+    if (options.to && options.fromSpot) {
+      if (!options.params) {
+        options.params = {}
       }
+      const positionParams = (
+        options.fromSpot.position
+          ? {
+              position: {
+                X: options.fromSpot.position.Xabs,
+                Y: options.fromSpot.position.Yabs,
+                scale: options.fromSpot.position.scale,
+                Xi: options.fromSpot.position.Xi,
+                Yi: options.fromSpot.position.Yi,
+                scalei: options.fromSpot.position.scalei
+              }
+            }
+          : {}
+      )
+      store.actions.setView(
+        {
+          name: options.to,
+          params: options.params
+        },
+        positionParams
+      )
     }
   },
   setView (data, options) {

--- a/src/store/modules/navigation.js
+++ b/src/store/modules/navigation.js
@@ -1,53 +1,6 @@
 import store from '../store'
 import Vue from 'vue'
-import { createUniqueKey } from '../utils'
-
-function retrieveViewName (pos) {
-  let viewName = ''
-  if (store.state.history.length >= pos) {
-    viewName = store.state.history[store.state.history.length - pos].name
-  }
-  return viewName
-}
-
-function transformViewName (view) {
-  view = view.toLowerCase()
-  let count = 0
-  for (let i = 1; i <= store.state.history.length; i++) {
-    if (store.state.history[store.state.history.length - i].name.split('--')[0] === view) {
-      count += 1
-    }
-  }
-  if (store.state.isRouterEnabled) {
-    return view
-  } else {
-    return view + '--' + count
-  }
-}
-
-function parseView (data) {
-  let name
-  let route
-  let paramPath = ''
-  let path
-  if (typeof data === 'string') {
-    name = transformViewName(data)
-    route = { name }
-    path = '/' + name
-  } else {
-    Object.keys(data.params).forEach(function (key) {
-      paramPath += '/:' + key
-    })
-    name = transformViewName(data.name)
-    route = { name, params: data.params }
-    path = '/' + name + '' + paramPath
-  }
-  return {
-    name,
-    route,
-    path
-  }
-}
+import { createUniqueKey, parseView, retrieveViewName } from '../utils'
 
 const navigation = {
   addToHistory (view, position, params) {

--- a/src/store/modules/router.js
+++ b/src/store/modules/router.js
@@ -1,11 +1,19 @@
 import store from '../store'
+import { createUniqueKey } from '../utils'
+
 const router = {
   evaluateRoute (view, position) {
     const match = store.state.router.resolve(view.path).route.matched[0]
     const component = match.components.default
     const name = match.name
     store.actions.setComponentList({ [name]: component })
-    store.state.history.push({ name, position, params: view.route.params, component })
+    store.state.history.push({
+      uniqueKey: createUniqueKey(),
+      name,
+      position,
+      params: view.route.params,
+      component
+    })
     store.actions.setNavigationMode('forward')
     if (view.name !== name) {
       return store.state.router.push({ name, params: view.route.params })
@@ -19,7 +27,13 @@ const router = {
     store.state.params = ''
     store.state.history = []
     store.actions.setComponentList({ [view.name]: component })
-    store.state.history.push({ name: view.name, position: { X: 0, Y: 0, scale: 1, Xi: 0, Yi: 0, scalei: 1 }, params: view.params, component })
+    store.state.history.push({
+      uniqueKey: createUniqueKey(),
+      name: view.name,
+      position: { X: 0, Y: 0, scale: 1, Xi: 0, Yi: 0, scalei: 1 },
+      params: view.params,
+      component
+    })
     store.actions.setNavigationMode('forward')
     store.state.router.replace(view)
     store.actions.setLog('replace() => ' + store.state.history[store.state.history.length - 1].name)

--- a/src/store/utils.js
+++ b/src/store/utils.js
@@ -1,1 +1,50 @@
+import store from '@/store/store'
+
 export const createUniqueKey = () => Date.now().toString(36) + Math.random().toString(36).substring(2)
+
+export function retrieveViewName (pos) {
+  let viewName = ''
+  if (store.state.history.length >= pos) {
+    viewName = store.state.history[store.state.history.length - pos].name
+  }
+  return viewName
+}
+
+export function transformViewName (view) {
+  view = view.toLowerCase()
+  let count = 0
+  for (let i = 1; i <= store.state.history.length; i++) {
+    if (store.state.history[store.state.history.length - i].name.split('--')[0] === view) {
+      count += 1
+    }
+  }
+  if (store.state.isRouterEnabled) {
+    return view
+  } else {
+    return view + '--' + count
+  }
+}
+
+export function parseView (data) {
+  let name
+  let route
+  let paramPath = ''
+  let path
+  if (typeof data === 'string') {
+    name = transformViewName(data)
+    route = { name }
+    path = '/' + name
+  } else {
+    Object.keys(data.params).forEach(function (key) {
+      paramPath += '/:' + key
+    })
+    name = transformViewName(data.name)
+    route = { name, params: data.params }
+    path = '/' + name + '' + paramPath
+  }
+  return {
+    name,
+    route,
+    path
+  }
+}

--- a/src/store/utils.js
+++ b/src/store/utils.js
@@ -3,45 +3,37 @@ import store from '@/store/store'
 export const createUniqueKey = () => Date.now().toString(36) + Math.random().toString(36).substring(2)
 
 export function retrieveViewName (pos) {
-  let viewName = ''
-  if (store.state.history.length >= pos) {
-    viewName = store.state.history[store.state.history.length - pos].name
+  if (store.state.history.length <= pos) {
+    return ''
   }
-  return viewName
+  return store.state.history[store.state.history.length - pos].name
 }
 
 export function transformViewName (view) {
   view = view.toLowerCase()
   let count = 0
-  for (let i = 1; i <= store.state.history.length; i++) {
-    if (store.state.history[store.state.history.length - i].name.split('--')[0] === view) {
-      count += 1
-    }
+
+  if (!store.state.isRouterEnabled) {
+    count = store.state.history.filter((historicView) => historicView.name.startsWith(view)).length
+    view += '--' + count
   }
-  if (store.state.isRouterEnabled) {
-    return view
-  } else {
-    return view + '--' + count
-  }
+  return view
 }
 
 export function parseView (data) {
-  let name
-  let route
-  let paramPath = ''
-  let path
-  if (typeof data === 'string') {
-    name = transformViewName(data)
-    route = { name }
-    path = '/' + name
-  } else {
+  const baseName = (typeof data === 'object') ? data.name : data
+  const name = transformViewName(baseName)
+  const route = { name, params: data.params }
+  let path = '/' + name
+
+  if (typeof data === 'object' && typeof data.params === 'object') {
+    let paramPath = ''
     Object.keys(data.params).forEach(function (key) {
       paramPath += '/:' + key
     })
-    name = transformViewName(data.name)
-    route = { name, params: data.params }
-    path = '/' + name + '' + paramPath
+    path += paramPath
   }
+
   return {
     name,
     route,

--- a/src/store/utils.js
+++ b/src/store/utils.js
@@ -1,0 +1,1 @@
+export const createUniqueKey = () => Date.now().toString(36) + Math.random().toString(36).substring(2)


### PR DESCRIPTION
This is just refactoring based on my vision of the code, but you can code as you want and reject these changes without any problem for me ;) 

As indicated in the titles of the commits, here is what I did:
- reduce shape methods complexity by returning is-circle by default
- remove unused ffox data properties
- 
use watch on responsive property to avoid side effects in computed properties
- 
improve template format to respect 2 spaces indentation
- reduce toView method complexity (sonarlint issue)
- move navigation utils functions in utils file
- 
refactor retrieveViewName, transformViewName and parseView methods

This is just refactoring based on my vision of the code, but you can code as you want and reject these changes without any problem for me ;) 

I suggest merging the PR 58 first (https://github.com/zircleUI/zircleUI/pull/58), as I have merged the PR 58 branch into this PR