### PR TITLE
Minor global refactoring (but working, this time)

### DIFF
--- a/src/store/modules/navigation.js
+++ b/src/store/modules/navigation.js
@@ -99,18 +99,33 @@ const navigation = {
     }
   },
   setView (data, options) {
-    if (store.state.history.length < 6 && store.state.isRouterEnabled === false) {
-      const view = parseView(data)
-      const position = !options ? { X: 0, Y: 0, scale: 1, Xi: 0, Yi: 0, scalei: 1 } : options.position
+    if (store.state.history.length >= 6) {
+      store.actions.setLog('Max zoom level reached')
+      return
+    }
+
+    const view = parseView(data)
+    const position = (
+      !options || (options.position && options.position.scale === 0)
+        ? {
+            X: 0,
+            Y: 0,
+            scale: 1,
+            Xi: 0,
+            Yi: 0,
+            scalei: 1
+          }
+        : options.position
+    )
+
+    if (store.state.isRouterEnabled === false) {
       store.actions.addToHistory(view, position, view.route.params)
       store.actions.setNavigationMode('forward')
-      if (view.route) store.state.params = view.route.params
-    } else if (store.state.history.length < 6 && store.state.isRouterEnabled === true) {
-      const view = parseView(data)
-      const position = !options ? { X: 0, Y: 0, scale: 1, Xi: 0, Yi: 0, scalei: 1 } : options.position
-      store.actions.evaluateRoute(view, position)
+      if (view.route) {
+        store.state.params = view.route.params
+      }
     } else {
-      store.actions.setLog('Max zoom level reached')
+      store.actions.evaluateRoute(view, position)
     }
   },
   goBack () {

--- a/src/store/utils.js
+++ b/src/store/utils.js
@@ -3,7 +3,7 @@ import store from '@/store/store'
 export const createUniqueKey = () => Date.now().toString(36) + Math.random().toString(36).substring(2)
 
 export function retrieveViewName (pos) {
-  if (store.state.history.length <= pos) {
+  if (store.state.history.length < pos || pos < 1) {
     return ''
   }
   return store.state.history[store.state.history.length - pos].name


### PR DESCRIPTION
Based on this PR https://github.com/zircleUI/zircleUI/pull/59

I fixed the bug due to a change in the retrieveViewName function
`if (store.state.history.length >= pos)` instead of  `if (store.state.history.length > pos)`

I did it thinking about the possitility of having an index out of range of the history (`store.state.history[store.state.history.length - pos].name`) but it was not the right thing to do at all.
Do we agree that the "pos" parameter can't be less than 1 in this method ? 


Btw, I added the scale fix (https://github.com/zircleUI/zircleUI/pull/53/) which is not on the dev branch, probably due to a merge error
