### PR TITLE
Fix positions issues due to OS display scale

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -86,6 +86,8 @@ export default {
     sun
   },
   mounted () {
+    document.body.style.zoom = 1 / window.devicePixelRatio
+
     this.$zircle.config({
       debug: true,
       style: {


### PR DESCRIPTION
Adapt body zoom to pixel ratio in order to fix positions issues due to OS display scale

**Example with 125% display scale on Windows 11:**
### Without fix
![photo1660598711](https://user-images.githubusercontent.com/8525765/184732420-2b18ba1a-b040-411e-b021-c934a57b7853.jpeg)

### With change
![photo1660598761](https://user-images.githubusercontent.com/8525765/184732425-59139535-adb5-40f7-91a5-871d96a7fb43.jpeg)

